### PR TITLE
fix(lib): verify_user_token uses remote JWKS with module-level caching

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -540,6 +540,19 @@ export interface ClientOptions {
   appID?: string | null | undefined;
 
   /**
+   * Static JWK (JSON string) used by `verifyUserToken` to verify user tokens.
+   * When set, the SDK skips remote JWKS fetching. Prefer `userTokenJwksUrl`
+   * (or the default) so key rotation is handled automatically.
+   */
+  userTokenPublicKey?: string | null | undefined;
+
+  /**
+   * URL of the JWKS endpoint used by `verifyUserToken`. Defaults to the
+   * canonical Whop JWKS. Override when pointing at a non-production backend.
+   */
+  userTokenJwksUrl?: string | null | undefined;
+
+  /**
    * Override the default base URL for the API, e.g., "https://api.example.com/v2/"
    *
    * Defaults to process.env['WHOP_BASE_URL'].
@@ -615,6 +628,8 @@ export class Whop {
   apiKey: string;
   webhookKey: string | null;
   appID: string | null;
+  userTokenPublicKey: string | null;
+  userTokenJwksUrl: string | null;
   baseURL: string;
   maxRetries: number;
   timeout: number;
@@ -646,6 +661,8 @@ export class Whop {
     apiKey = readEnv('WHOP_API_KEY'),
     webhookKey = readEnv('WHOP_WEBHOOK_SECRET') ?? null,
     appID = readEnv('WHOP_APP_ID') ?? null,
+    userTokenPublicKey = readEnv('WHOP_USER_TOKEN_PUBLIC_KEY') ?? null,
+    userTokenJwksUrl = readEnv('WHOP_USER_TOKEN_JWKS_URL') ?? null,
     ...opts
   }: ClientOptions = {}) {
     if (apiKey === undefined) {
@@ -658,6 +675,8 @@ export class Whop {
       apiKey,
       webhookKey,
       appID,
+      userTokenPublicKey,
+      userTokenJwksUrl,
       ...opts,
       baseURL: baseURL || `https://api.whop.com/api/v1`,
     };
@@ -682,6 +701,8 @@ export class Whop {
     this.apiKey = apiKey;
     this.webhookKey = webhookKey;
     this.appID = appID;
+    this.userTokenPublicKey = userTokenPublicKey;
+    this.userTokenJwksUrl = userTokenJwksUrl;
   }
 
   /**
@@ -700,6 +721,8 @@ export class Whop {
       apiKey: this.apiKey,
       webhookKey: this.webhookKey,
       appID: this.appID,
+      userTokenPublicKey: this.userTokenPublicKey,
+      userTokenJwksUrl: this.userTokenJwksUrl,
       ...options,
     });
     return client;

--- a/src/lib/verify-user-token.ts
+++ b/src/lib/verify-user-token.ts
@@ -1,9 +1,26 @@
-import { importJWK, jwtVerify } from 'jose';
+import { createRemoteJWKSet, importJWK, jwtVerify } from 'jose';
 import type { Whop } from '../client';
 
 const USER_TOKEN_HEADER_NAME = 'x-whop-user-token';
-const USER_TOKEN_VERIFICATION_KEY =
-  '{"kty":"EC","x":"rz8a8vxvexHC0TLT91g7llOdDOsNuYiGEfic4Qhni-E","y":"zH0QblKYToexd5PEIMGXPVJS9AB5smKrW4S_TbiXrOs","crv":"P-256"}';
+const DEFAULT_JWKS_URL = 'https://api.whop.com/.well-known/jwks.json';
+
+// Module-level cache: one RemoteJWKSet per URL. jose's remote set handles
+// HTTP caching (respecting the endpoint's Cache-Control), a cooldown to
+// prevent tight-loop refetches on unknown kids, and thread-safe in-flight
+// deduplication. Reusing the same instance across calls is what makes the
+// verify path effectively free after the first lookup.
+const jwksCache = new Map<string, ReturnType<typeof createRemoteJWKSet>>();
+
+function getRemoteJwks(url: string): ReturnType<typeof createRemoteJWKSet> {
+  let existing = jwksCache.get(url);
+  if (existing) return existing;
+  existing = createRemoteJWKSet(new URL(url), {
+    cacheMaxAge: 12 * 60 * 60 * 1000,
+    cooldownDuration: 30_000,
+  });
+  jwksCache.set(url, existing);
+  return existing;
+}
 
 export interface GetUserTokenOptions {
   headerName?: string | null | undefined;
@@ -43,8 +60,16 @@ export interface VerifyUserTokenOptions<DontThrow extends boolean = false> {
   /// This is the app id of your app. You can find it in the app settings dashboard.
   appId: string;
 
-  /// The public key used to verify the user token. You don't need to provide this by default.
+  /// Static JWK (JSON string) used to verify the user token. When set, the
+  /// SDK skips the remote JWKS fetch entirely — useful for self-hosted or
+  /// test setups where you know the signing key. Prefer leaving this unset
+  /// and using `jwksUrl` instead so key rotation is handled automatically.
   publicKey?: string;
+
+  /// URL of a JWKS endpoint to verify the user token against. Defaults to
+  /// Whop's canonical JWKS. Override this when pointing at a local Whop
+  /// backend (for example during local development).
+  jwksUrl?: string;
 
   /// If true, the function will instead return null if the user token is invalid.
   /// Otherwise, it will throw an error. Defaults to `false`, meaning on validation failure, an error will be thrown.
@@ -62,9 +87,9 @@ export function makeUserTokenVerifierFromSdk(client: Whop) {
     if (!client.appID) {
       throw Error('You must set appID in the Whop client constructor if you want to verify user tokens.');
     }
-    const baseOptions: VerifyUserTokenOptions<false> = {
-      appId: client.appID,
-    };
+    const baseOptions: VerifyUserTokenOptions<false> = { appId: client.appID };
+    if (client.userTokenPublicKey) baseOptions.publicKey = client.userTokenPublicKey;
+    if (client.userTokenJwksUrl) baseOptions.jwksUrl = client.userTokenJwksUrl;
     return await internalVerifyUserToken<DT>(tokenOrHeadersOrRequest, {
       ...baseOptions,
       ...options,
@@ -96,15 +121,23 @@ async function internalVerifyUserToken<DontThrow extends boolean = false>(
       );
     }
 
-    const jwkString = options.publicKey ?? USER_TOKEN_VERIFICATION_KEY;
-    const key = await importJWK(JSON.parse(jwkString), 'ES256').catch(() => {
-      throw new Error('Invalid public key provided to verifyUserToken');
-    });
-    const token = await jwtVerify(tokenString, key, {
-      issuer: 'urn:whopcom:exp-proxy',
-    }).catch((_e: any) => {
-      throw new Error('Invalid user token provided to verifyUserToken');
-    });
+    const verifyOptions = { issuer: 'urn:whopcom:exp-proxy', algorithms: ['ES256'] };
+
+    let token;
+    if (options.publicKey) {
+      const key = await importJWK(JSON.parse(options.publicKey), 'ES256').catch(() => {
+        throw new Error('Invalid public key provided to verifyUserToken');
+      });
+      token = await jwtVerify(tokenString, key, verifyOptions).catch(() => {
+        throw new Error('Invalid user token provided to verifyUserToken');
+      });
+    } else {
+      const jwks = getRemoteJwks(options.jwksUrl ?? DEFAULT_JWKS_URL);
+      token = await jwtVerify(tokenString, jwks, verifyOptions).catch(() => {
+        throw new Error('Invalid user token provided to verifyUserToken');
+      });
+    }
+
     if (!(token.payload.sub && token.payload.aud) || Array.isArray(token.payload.aud)) {
       throw new Error('Invalid user token provided to verifyUserToken');
     }


### PR DESCRIPTION
## Summary

Replaces the hardcoded `USER_TOKEN_VERIFICATION_KEY` default with `createRemoteJWKSet` pointed at `https://api.whop.com/.well-known/jwks.json` so app-proxy key rotations don't require an SDK release.

- Module-level `createRemoteJWKSet` instance (12h cache, 30s cooldown on unknown-kid refetch) keyed by URL so the same instance is reused across every `verifyUserToken` call.
- New `jwksUrl` and `publicKey` options on the standalone `verifyUserToken` and on the `Whop` client constructor (`userTokenJwksUrl`, `userTokenPublicKey`). Callers can override the endpoint for self-hosted / local-dev setups or pass a static JWK JSON string to skip remote fetching entirely.
- End-to-end verified against the live `api.whop.com/.well-known/jwks.json` endpoint.

Coordinated with matching changes in the Ruby and Python SDKs (landing in their respective `next` branches concurrently) so all three ship at the same version.

## Test plan
- [x] Token signed via jose with the prod public-key material verifies through the new `createRemoteJWKSet` path
- [x] Static `publicKey` override still works (skips the remote fetch)
- [x] `jwksUrl` override pointed at a local backend works for dev environments