### PR TITLE
ci: fix npm publish broken by npm 12 allow-remote default

### DIFF
--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -29,7 +29,9 @@ jobs:
           node-version: '22'
 
       - name: Set up npm
-        run: npm install -g npm@latest
+        # npm 12 defaults allow-remote to "none", which blocks the jq-web
+        # tarball-URL dependency in the MCP server bundle (EALLOWREMOTE)
+        run: npm install -g npm@11
 
       - name: Set up pnpm
         uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4.3.0
@@ -50,6 +52,7 @@ jobs:
           INPUT_PATH: ${{ github.event.inputs.path }}
 
       - name: Upload MCP Server DXT GitHub release asset
+        if: github.event_name == 'release'
         run: |
           gh release upload ${{ github.event.release.tag_name }} \
             packages/mcp-server/whop_sdk_api.mcpb

--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -43,7 +43,7 @@ jobs:
       - name: Publish to NPM
         run: |
           if [ -n "$INPUT_PATH" ]; then
-            PATHS_RELEASED="[\"$INPUT_PATH\"]"
+            PATHS_RELEASED="[\\\"$INPUT_PATH\\\"]"
           else
             PATHS_RELEASED='[\".\", \"packages/mcp-server\"]'
           fi

--- a/bin/publish-npm
+++ b/bin/publish-npm
@@ -2,7 +2,9 @@
 
 set -eux
 
-npm config set '//registry.npmjs.org/:_authToken' "$NPM_TOKEN"
+if [ -n "${NPM_TOKEN:-}" ]; then
+  npm config set '//registry.npmjs.org/:_authToken' "$NPM_TOKEN"
+fi
 
 pnpm build
 cd dist


### PR DESCRIPTION
The v0.0.41 npm publish failed with EALLOWREMOTE: npm 12 (installed via `npm install -g npm@latest`) defaults `allow-remote` to `none`, so the MCP server dist-bundle `npm install` refuses the `jq-web` tarball-URL dependency.

- Pin npm to v11 (still supports OIDC trusted publishing; matches the behavior that published v0.0.40)
- Skip the release-asset upload step on manual `workflow_dispatch` runs, which have no release tag, so the workflow can be re-run to re-publish v0.0.41

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RH61sMw2V5YuXYWi63yEsc