### PR TITLE
chore: protect the npm release machinery from Fern regeneration

### DIFF
--- a/.fernignore
+++ b/.fernignore
@@ -1,0 +1,16 @@
+# Files Fern must not modify or delete when regenerating this repo.
+#
+# This repo's npm release machinery is Stainless-generated (release-please for
+# versioning, publish-npm.yml for the tag/release-triggered publish). The Fern
+# pipeline in whop-monorepo/sdks/fern regenerates the SDK source here via PRs,
+# and without this file those PRs delete the release machinery wholesale
+# (observed on PR #59). Protect it until the post-cutover publish mechanism
+# replaces it deliberately.
+.github/workflows/publish-npm.yml
+.github/workflows/release-please.yml
+.github/workflows/release-doctor.yml
+.release-please-manifest.json
+release-please-config.json
+bin/publish-npm
+bin/check-release-environment
+scripts/publish-packages.ts


### PR DESCRIPTION
Fern's SDK-regeneration PRs (from `whop-monorepo/sdks/fern`) delete this repo's Stainless-generated release machinery wholesale — #59 currently shows `publish-npm.yml`, `release-please.yml`, `release-doctor.yml`, both release-please configs, and `bin/publish-npm` as removed.

`.fernignore` is Fern's supported mechanism for files it must not touch. This lists the release machinery and the scripts it runs (`bin/publish-npm`, `bin/check-release-environment`, `scripts/publish-packages.ts`), so a merged Fern PR cannot silently remove the ability to publish `@whop/sdk`.

This is a stopgap for the coexistence window, not the end state: under a Fern-generated tree release-please only half-works (its scripts assume Stainless's layout and commit style). The durable publish mechanism is being decided in the cutover work on whop-monorepo#24216.

Must merge before #59 or any other Fern PR here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)