### PR TITLE
fix: unbreak the publish workflow (pnpm cache probe)

### DIFF
--- a/.github/workflows/publish-main.yml
+++ b/.github/workflows/publish-main.yml
@@ -1,11 +1,6 @@
 name: Publish
 
 on:
-  # A release is a one-line PR bumping "version" in package.json. The decide job below
-  # checks that the push changed nothing else in package.json, so a Fern regeneration —
-  # which rewrites the whole file — can never be mistaken for one, whatever version it
-  # happens to carry. Re-dispatch from main to retry: publishing is skipped when the
-  # version is already on npm.
   push:
     branches: [main]
     paths: ["package.json"]
@@ -14,8 +9,6 @@ on:
 permissions:
   contents: read
 
-# Serialize: two pushes touching package.json must not both decide a version is
-# unpublished and race each other to the registry.
 concurrency:
   group: publish-whop-sdk
   cancel-in-progress: false
@@ -23,8 +16,6 @@ concurrency:
 jobs:
   decide:
     runs-on: ubuntu-latest
-    # Trusted publishing matches on repo + workflow filename, not git ref, so a dispatch
-    # from any branch would authenticate. Pin it to main.
     if: github.ref == 'refs/heads/main'
     outputs:
       release: ${{ steps.check.outputs.release }}
@@ -38,8 +29,6 @@ jobs:
       - uses: actions/setup-node@v5
         with:
           node-version: "22"
-          # packageManager in package.json makes setup-node try to prime a pnpm cache,
-          # which fails before corepack has installed pnpm. Only the build job uses it.
           package-manager-cache: false
 
       - name: Is this a release?
@@ -51,8 +40,6 @@ jobs:
           version=$(node -p "require('./package.json').version")
           echo "version=$version" >> "$GITHUB_OUTPUT"
 
-          # Stable semver only. A prerelease would need a dist-tag decision this workflow
-          # does not make, and publishing one untagged repoints `latest` at it.
           if ! printf '%s' "$version" | grep -Eq '^[0-9]+\.[0-9]+\.[0-9]+$'; then
             echo "::error::'$version' is not stable semver; prereleases are not released from main."
             exit 1
@@ -79,8 +66,6 @@ jobs:
             fi
           fi
 
-          # Distinguish "not published" from "the registry call failed": treating an
-          # outage as "not published" would attempt a publish on an existing version.
           if out=$(npm view "@whop/sdk@$version" version 2>&1); then
             echo "@whop/sdk@$version is already published ($out) — nothing to release."
             echo "release=false" >> "$GITHUB_OUTPUT"
@@ -92,9 +77,6 @@ jobs:
             exit 1
           fi
 
-  # Deliberately separate from publish: installing and building runs third-party code
-  # (devDependencies, tsc, biome), which must not happen in a job carrying the publishing
-  # credential. This job has no id-token, so there is nothing to steal.
   build:
     needs: decide
     if: needs.decide.outputs.release == 'true'
@@ -107,14 +89,8 @@ jobs:
       - uses: actions/setup-node@v5
         with:
           node-version: "22"
-          # packageManager in package.json makes setup-node try to prime a pnpm cache,
-          # which fails before corepack has installed pnpm. Only the build job uses it.
           package-manager-cache: false
 
-      # Fern stamps the version into four files at generate time; a one-line version bump
-      # touches only package.json, so the other three would ship reporting the previous
-      # version — in SDK_VERSION and in the X-Fern-SDK-Version / User-Agent request
-      # headers. Re-derive them from package.json before building.
       - name: Sync the version stamps
         env:
           VERSION: ${{ needs.decide.outputs.version }}
@@ -158,22 +134,16 @@ jobs:
     needs: [decide, build]
     runs-on: ubuntu-latest
     permissions:
-      # npm Trusted Publishing: @whop/sdk trusts this repo+workflow as a publisher and
-      # npm authenticates with the OIDC token Actions mints for the run. The trusted
-      # publisher on npmjs.com must name THIS filename. Nothing else runs in this job.
       id-token: write
     steps:
       - uses: actions/setup-node@v5
         with:
           node-version: "22"
-          # packageManager in package.json makes setup-node try to prime a pnpm cache,
-          # which fails before corepack has installed pnpm. Only the build job uses it.
           package-manager-cache: false
 
       - name: Set up npm
         run: |
           set -euo pipefail
-          # Pinned: this runs in the job that can publish. Trusted publishing needs >=11.5.1.
           npm install -g npm@11.6.2
           npm --version
 
@@ -185,9 +155,6 @@ jobs:
       - name: Publish @whop/sdk
         run: npm publish /tmp/pack/*.tgz --access public
 
-  # Runs whenever the tag is missing, not only after a publish: if a publish succeeds and
-  # tagging fails, a re-run would otherwise see the version on npm, decide there is
-  # nothing to release, and never create the tag.
   tag:
     needs: [decide, publish]
     if: always() && needs.decide.outputs.version != '' && needs.publish.result != 'failure'

--- a/.github/workflows/publish-main.yml
+++ b/.github/workflows/publish-main.yml
@@ -38,6 +38,9 @@ jobs:
       - uses: actions/setup-node@v5
         with:
           node-version: "22"
+          # packageManager in package.json makes setup-node try to prime a pnpm cache,
+          # which fails before corepack has installed pnpm. Only the build job uses it.
+          package-manager-cache: false
 
       - name: Is this a release?
         id: check
@@ -104,6 +107,9 @@ jobs:
       - uses: actions/setup-node@v5
         with:
           node-version: "22"
+          # packageManager in package.json makes setup-node try to prime a pnpm cache,
+          # which fails before corepack has installed pnpm. Only the build job uses it.
+          package-manager-cache: false
 
       # Fern stamps the version into four files at generate time; a one-line version bump
       # touches only package.json, so the other three would ship reporting the previous
@@ -160,6 +166,9 @@ jobs:
       - uses: actions/setup-node@v5
         with:
           node-version: "22"
+          # packageManager in package.json makes setup-node try to prime a pnpm cache,
+          # which fails before corepack has installed pnpm. Only the build job uses it.
+          package-manager-cache: false
 
       - name: Set up npm
         run: |


### PR DESCRIPTION
The `Publish` run on main after #64 failed at `decide`:

```
##[error]Unable to locate executable file: pnpm.
```

`actions/setup-node` defaults `package-manager-cache: true`, and `package.json` declares `packageManager: pnpm@10.33.0`, so it tries to prime a pnpm cache — in a job that has no pnpm installed and does not need it. The old single-job workflow ran `corepack enable` up front, so splitting the jobs exposed this.

Sets `package-manager-cache: false` on all three `setup-node` steps; only the build job uses pnpm, and it enables corepack itself.

**Nothing published.** `decide` failed first and `build`, `publish`, and `tag` were all skipped — main is at 1.0.0, npm is still at 0.0.42. Merging this re-runs the pipeline (the push touches a workflow file, not `package.json`, so it will *not* trigger a release by itself — dispatch `Publish` from main once this is in, and the version guard will do the rest).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XV1533iUUxKJxfn4FXptWz