### PR TITLE
fix: create the pack destination, dryrun feature

### DIFF
--- a/.github/workflows/publish-main.yml
+++ b/.github/workflows/publish-main.yml
@@ -122,7 +122,9 @@ jobs:
           pnpm install --frozen-lockfile
           pnpm run build
           CI=true pnpm test
+          mkdir -p /tmp/pack
           npm pack --pack-destination /tmp/pack
+          ls -l /tmp/pack
 
       - uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/publish-main.yml
+++ b/.github/workflows/publish-main.yml
@@ -5,6 +5,11 @@ on:
     branches: [main]
     paths: ["package.json"]
   workflow_dispatch:
+    inputs:
+      dry_run:
+        description: "Run everything except the actual publish and tag"
+        type: boolean
+        default: false
 
 permissions:
   contents: read
@@ -35,10 +40,17 @@ jobs:
         id: check
         env:
           EVENT: ${{ github.event_name }}
+          DRY_RUN: ${{ inputs.dry_run }}
         run: |
           set -euo pipefail
           version=$(node -p "require('./package.json').version")
           echo "version=$version" >> "$GITHUB_OUTPUT"
+
+          if [ "$DRY_RUN" = "true" ]; then
+            echo "Dry run: exercising the pipeline without publishing or tagging."
+            echo "release=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
 
           if ! printf '%s' "$version" | grep -Eq '^[0-9]+\.[0-9]+\.[0-9]+$'; then
             echo "::error::'$version' is not stable semver; prereleases are not released from main."
@@ -155,11 +167,21 @@ jobs:
           path: /tmp/pack
 
       - name: Publish @whop/sdk
-        run: npm publish /tmp/pack/*.tgz --access public
+        env:
+          DRY_RUN: ${{ inputs.dry_run }}
+        run: |
+          set -euo pipefail
+          if [ "$DRY_RUN" = "true" ]; then
+            npm publish /tmp/pack/*.tgz --access public --dry-run
+            echo "Dry run: nothing was uploaded."
+            exit 0
+          fi
+
+          npm publish /tmp/pack/*.tgz --access public
 
   tag:
     needs: [decide, publish]
-    if: always() && needs.decide.outputs.version != '' && needs.publish.result != 'failure'
+    if: always() && inputs.dry_run != true && needs.decide.outputs.version != '' && needs.publish.result != 'failure'
     runs-on: ubuntu-latest
     permissions:
       contents: write


### PR DESCRIPTION
The 1.0.1 publish run got through install, build, and the full test suite (118 files, 2460 tests) and then failed on the last command:

```
npm error enoent ENOENT: no such file or directory, open '/tmp/pack/whop-sdk-1.0.1.tgz'
```

`npm pack --pack-destination` does not create the directory. Adds `mkdir -p /tmp/pack`, plus an `ls -l` so the artifact is visible in the log.

**Nothing published, nothing tagged.** `publish` was skipped because `build` failed, and the `tag` job's own npm check saw 1.0.1 was absent from the registry and exited without creating a tag — the guards behaved correctly.

After this merges, 1.0.1 is still sitting on main unpublished, and merging this PR will not release it (it touches a workflow file, not `package.json`). Dispatch `Publish` from main to ship it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XV1533iUUxKJxfn4FXptWz