### PR TITLE
fix: refuse to publish when package.json is behind npm

### DIFF
--- a/.github/workflows/publish-main.yml
+++ b/.github/workflows/publish-main.yml
@@ -78,6 +78,15 @@ jobs:
             fi
           fi
 
+          latest=$(npm view "@whop/sdk" version 2>/dev/null || true)
+          if [ -n "$latest" ] && [ "$latest" != "$version" ]; then
+            highest=$(printf '%s\n%s\n' "$latest" "$version" | sort -V | tail -1)
+            if [ "$highest" = "$latest" ]; then
+              echo "::error::package.json is $version but npm already has $latest. A regeneration pinned to a stale version would silently downgrade main; bump past $latest instead."
+              exit 1
+            fi
+          fi
+
           if out=$(npm view "@whop/sdk@$version" version 2>&1); then
             echo "@whop/sdk@$version is already published ($out) — nothing to release."
             echo "release=false" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
### Why

The Fern train pins generated packages to `npm view @whop/sdk version` **at generation time**. Any regeneration PR opened before a release therefore carries a stale version — open PR #70 holds `0.0.42` while npm now has `1.0.11`.

Merging such a PR moves `main`'s version backwards, and the failure is silent: `decide` sees `0.0.42` already published, concludes "nothing to release", and exits green. `main` would sit on a stale version until someone noticed by eye.

### What changed

`decide` now hard-fails when `package.json`'s version is **lower** than npm's latest, naming the version to bump past. Verified against the cases that matter:

| npm | package.json | result |
|---|---|---|
| 1.0.11 | 0.0.42 | blocked (this is PR #70) |
| 1.0.11 | 1.0.9 | blocked |
| 1.0.11 | 1.0.11 | allowed — the no-op path |
| 1.0.11 | 1.0.12 / 2.0.0 | allowed |
| unreachable | 1.0.12 | allowed — no false block on a registry blip |

Because it runs in `decide`, it also fires on **pull requests** (the workflow dry-runs every PR), so a stale regeneration PR goes red before merge rather than after.

### Note on #70

This makes #70 fail its check rather than silently downgrade main. The cleaner fix for that PR specifically is to close it and let the next train run re-pin at 1.0.11.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XV1533iUUxKJxfn4FXptWz