### PR TITLE
release: 1.0.12

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@whop/sdk",
-    "version": "1.0.11",
+    "version": "1.0.12",
     "private": false,
     "repository": {
         "type": "git",


### PR DESCRIPTION
Bumps `version` in `package.json` from 1.0.11 to 1.0.12. Nothing else changes.

**Merging this publishes `@whop/sdk@1.0.12` to npm.** The push to `main` triggers `publish-main.yml`, which builds, tests, packs, publishes via npm trusted publishing (OIDC), then tags `v1.0.12` and cuts a GitHub Release.

This release has real content: it ships the SDK regeneration merged in #72 (240 files — new/changed types across Bounty, Invoice, StorefrontAccount, User, Webhook, and others), which landed after v1.0.11 was tagged and so is not yet on npm.