### PR TITLE
feat(helpers): restore webhook signature verification

### DIFF
--- a/.fernignore
+++ b/.fernignore
@@ -3,4 +3,31 @@
 # Fern owns the SDK source and its ci.yml. publish-main.yml is hand-written: it releases
 # @whop/sdk when a merge to main lands a package.json version that is not yet on npm.
 # scripts/rename-to-esm-files.js is Fern's own and is deliberately not listed.
+#
+# src/helpers holds unwrapWebhook, the one hand-written helper in this SDK — the Standard
+# Webhooks signature verifier. It restores the verification half of
+# `client.webhooks.unwrap`, which the Stainless-generated package shipped through 0.0.42
+# and Fern cannot generate: Fern generates from OpenAPI paths and `unwrap` was never a
+# path. It depends only on standardwebhooks, never on generated client code, so it
+# survives the client being replaced.
+#
+# This entry only keeps the files. Two things the helper needs are in package.json, which
+# is generated, and are restored from the typescript config in whop-monorepo's
+# sdks/fern/generators.yml, not from here:
+#
+#   - the `standardwebhooks` dependency, from `extraDependencies`. The helper imports it
+#     at module load, so without the declaration the import fails to resolve for callers.
+#   - the `./helpers` subpath in `exports`, from `packageJson`, which the generator merges
+#     into the package.json it writes. src/index.ts is generated too, so re-exporting from
+#     the package root would mean forking a generated file; a subpath does not.
+#
+# The two travel together: re-emitting the export without the dependency turns a silently
+# missing helper into a resolution error for anyone who imports `@whop/sdk/helpers`.
+# tests/unit/helpers asserts both every run, alongside the verifier's own tests, so a
+# regeneration that drops either fails in CI instead of on a caller's machine. (Ruby puts
+# the equivalent guard in ci.yml, which it already keeps hand-written for an unrelated
+# security reason; this repo's ci.yml is Fern's and forking it for a guard is a worse
+# trade than putting the guard in a test.)
 .github/workflows/publish-main.yml
+src/helpers
+tests/unit/helpers

--- a/package.json
+++ b/package.json
@@ -1089,6 +1089,17 @@
             },
             "default": "./dist/cjs/api/resources/users/resources/preferences/resources/notifications/resources/topics/exports.js"
         },
+        "./helpers": {
+            "import": {
+                "types": "./dist/esm/helpers/index.d.mts",
+                "default": "./dist/esm/helpers/index.mjs"
+            },
+            "require": {
+                "types": "./dist/cjs/helpers/index.d.ts",
+                "default": "./dist/cjs/helpers/index.js"
+            },
+            "default": "./dist/cjs/helpers/index.js"
+        },
         "./package.json": "./package.json"
     },
     "files": [
@@ -1111,7 +1122,9 @@
         "test:unit": "vitest --project unit",
         "test:wire": "vitest --project wire"
     },
-    "dependencies": {},
+    "dependencies": {
+        "standardwebhooks": "^1.0.0"
+    },
     "devDependencies": {
         "webpack": "^5.105.4",
         "ts-loader": "^9.5.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,6 +7,10 @@ settings:
 importers:
 
   .:
+    dependencies:
+      standardwebhooks:
+        specifier: ^1.0.0
+        version: 1.0.0
     devDependencies:
       '@biomejs/biome':
         specifier: 2.4.10
@@ -261,6 +265,9 @@ packages:
   '@rolldown/pluginutils@1.0.1':
     resolution: {integrity: sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==}
 
+  '@stablelib/base64@1.0.1':
+    resolution: {integrity: sha512-1bnPQqSxSuc3Ii6MhBysoWCg58j97aUjuCSZrGSmDxNqtytIi0k8utUenAwTZN4V5mXXYGsVUI9zeBqy+jBOSQ==}
+
   '@standard-schema/spec@1.1.0':
     resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
 
@@ -501,6 +508,9 @@ packages:
 
   fast-deep-equal@3.1.3:
     resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
+
+  fast-sha256@1.3.0:
+    resolution: {integrity: sha512-n11RGP/lrWEFI/bWdygLxhI+pVeo1ZYIVwvvPkW7azl/rOy+F3HYRZ2K5zeE9mmkhQppyv9sQFx0JM9UabnpPQ==}
 
   fast-uri@3.1.5:
     resolution: {integrity: sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==}
@@ -772,6 +782,9 @@ packages:
 
   stackback@0.0.2:
     resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
+
+  standardwebhooks@1.0.0:
+    resolution: {integrity: sha512-BbHGOQK9olHPMvQNHWul6MYlrRTAOKn03rOe4A8O3CLWhNf4YHBqq2HJKKC+sfqpxiBY52pNeesD6jIiLDz8jg==}
 
   statuses@2.0.2:
     resolution: {integrity: sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==}
@@ -1153,6 +1166,8 @@ snapshots:
 
   '@rolldown/pluginutils@1.0.1': {}
 
+  '@stablelib/base64@1.0.1': {}
+
   '@standard-schema/spec@1.1.0': {}
 
   '@types/chai@5.2.3':
@@ -1403,6 +1418,8 @@ snapshots:
 
   fast-deep-equal@3.1.3: {}
 
+  fast-sha256@1.3.0: {}
+
   fast-uri@3.1.5: {}
 
   fdir@6.5.0(picomatch@4.0.5):
@@ -1601,6 +1618,11 @@ snapshots:
   source-map@0.7.6: {}
 
   stackback@0.0.2: {}
+
+  standardwebhooks@1.0.0:
+    dependencies:
+      '@stablelib/base64': 1.0.1
+      fast-sha256: 1.3.0
 
   statuses@2.0.2: {}
 

--- a/src/helpers/index.ts
+++ b/src/helpers/index.ts
@@ -1,0 +1,2 @@
+export type { UnwrapWebhookOptions } from "./verifyWebhook.js";
+export { MISSING_KEY_MESSAGE, unwrapWebhook, WebhookVerificationError } from "./verifyWebhook.js";

--- a/src/helpers/verifyWebhook.ts
+++ b/src/helpers/verifyWebhook.ts
@@ -21,12 +21,43 @@ export interface UnwrapWebhookOptions {
      * are read, and the lookup is case-insensitive.
      */
     headers: Record<string, string>;
-    /** The endpoint's signing secret, with or without the `whsec_` prefix. */
+    /**
+     * The endpoint's signing secret, exactly as Whop shows it — a `ws_`-prefixed string.
+     * Pass it verbatim; do not strip the prefix and do not pre-encode it.
+     */
     key: string | undefined;
 }
 
 export const MISSING_KEY_MESSAGE =
     "Cannot verify a webhook without a key. Pass the endpoint's signing secret as `key`.";
+
+/**
+ * Base64-encode the secret so `Webhook` derives the key Whop actually signs with.
+ *
+ * Whop's backend HMACs with the *literal bytes* of the secret it issued
+ * (`WebhooksManager::SignWebhook` passes `webhook.webhook_secret` straight to
+ * `OpenSSL::HMAC`). `standardwebhooks`' `Webhook` instead base64-decodes whatever it is
+ * handed to derive its key, so handing it the secret raw derives the wrong key — and,
+ * because its decoder is strict, a `ws_` secret does not even fail as a verification
+ * error: `_` is outside the base64 alphabet, so the constructor throws
+ * `Base64Coder: incorrect characters for decoding`. Encoding here cancels that decode
+ * out, leaving exactly the bytes the backend signed with.
+ *
+ * The whole secret is encoded, prefix included, because the backend never strips a prefix
+ * either. That also disarms the library's own `whsec_` stripping: base64 output cannot
+ * begin with `whsec_`, since `_` is not in the base64 alphabet.
+ *
+ * `TextEncoder`/`btoa` rather than `Buffer` so this holds outside Node too — the secret is
+ * encoded as UTF-8, not latin1, which `btoa` alone would get wrong for a non-ASCII secret.
+ */
+function hmacKey(key: string): string {
+    const bytes = new TextEncoder().encode(key);
+    let binary = "";
+    for (const byte of bytes) {
+        binary += String.fromCharCode(byte);
+    }
+    return btoa(binary);
+}
 
 /**
  * Verifies `payload` against the signature headers and returns the parsed body.
@@ -49,7 +80,7 @@ export function unwrapWebhook<TEvent = Record<string, unknown>>(
         throw new Error(MISSING_KEY_MESSAGE);
     }
 
-    return new Webhook(key).verify(payload, headers) as TEvent;
+    return new Webhook(hmacKey(key)).verify(payload, headers) as TEvent;
 }
 
 export { WebhookVerificationError };

--- a/src/helpers/verifyWebhook.ts
+++ b/src/helpers/verifyWebhook.ts
@@ -1,0 +1,55 @@
+import { Webhook, WebhookVerificationError } from "standardwebhooks";
+
+/**
+ * Verify the Standard Webhooks signature Whop sends on every webhook delivery.
+ *
+ * This is the verification half of the `client.webhooks.unwrap` the Stainless-generated
+ * `@whop/sdk` shipped through 0.0.42. Fern generates from OpenAPI paths and `unwrap` was
+ * never a path, so the generated client has no equivalent. It is a standalone function
+ * rather than a method on the client so that nothing generated has to be patched: it
+ * depends only on `standardwebhooks`, never on generated client code, so it survives the
+ * client being replaced.
+ *
+ * It does NOT coerce the parsed body into a typed event model, which the Stainless
+ * version did through a union of 42 of them. Fern generates no webhook event models —
+ * `Whop.WebhookEvent` is the enum of event *names* a webhook subscribes to, not a payload
+ * type — so there is nothing to coerce into.
+ */
+export interface UnwrapWebhookOptions {
+    /**
+     * The request headers. Only `webhook-id`, `webhook-timestamp` and `webhook-signature`
+     * are read, and the lookup is case-insensitive.
+     */
+    headers: Record<string, string>;
+    /** The endpoint's signing secret, with or without the `whsec_` prefix. */
+    key: string | undefined;
+}
+
+export const MISSING_KEY_MESSAGE =
+    "Cannot verify a webhook without a key. Pass the endpoint's signing secret as `key`.";
+
+/**
+ * Verifies `payload` against the signature headers and returns the parsed body.
+ *
+ * @param payload The raw, unmodified request body. Verifying a re-serialized body fails:
+ * the signature covers the exact bytes sent. In Next.js that is `await request.text()`,
+ * never `await request.json()`.
+ * @throws {Error} when `key` is missing or empty.
+ * @throws {WebhookVerificationError} when a signature header is missing or malformed, the
+ * timestamp is outside the tolerance window, or no signature matches.
+ *
+ * `TEvent` is an unchecked assertion on the parsed body, not a validated shape — nothing
+ * here checks the payload against it.
+ */
+export function unwrapWebhook<TEvent = Record<string, unknown>>(
+    payload: string,
+    { headers, key }: UnwrapWebhookOptions,
+): TEvent {
+    if (!key) {
+        throw new Error(MISSING_KEY_MESSAGE);
+    }
+
+    return new Webhook(key).verify(payload, headers) as TEvent;
+}
+
+export { WebhookVerificationError };

--- a/tests/unit/helpers/verifyWebhook.test.ts
+++ b/tests/unit/helpers/verifyWebhook.test.ts
@@ -1,10 +1,34 @@
+import { createHmac } from "node:crypto";
 import { readFileSync } from "node:fs";
-import { Webhook, WebhookVerificationError } from "standardwebhooks";
+import { WebhookVerificationError } from "standardwebhooks";
 import { unwrapWebhook } from "../../../src/helpers/index.js";
 
-const KEY = "whsec_MfKQ9r8GKYqrTwjUPD8ILPZIo2LaLaSw";
-const OTHER_KEY = "whsec_C2FVsBQIhrscChlQIMV+b5sSYspob7oD";
+// The format WebhooksManager::Create issues: "ws_" + SecureRandom.hex(32).
+const KEY = `ws_${"3f2a".repeat(16)}`;
+const OTHER_KEY = `ws_${"c17b".repeat(16)}`;
 const PAYLOAD = '{"id":"evt_123","event":"payment.succeeded","data":{"id":"pay_123"}}';
+
+/**
+ * Reproduces backend/app/services/webhooks_manager/sign_webhook.rb — deliberately not the
+ * library under test. Signing and verifying with the same library is self-consistent and
+ * proved nothing: it agreed with itself while rejecting every genuine Whop delivery.
+ *
+ *   payload   = "#{id}.#{timestamp}.#{body_json}"
+ *   raw_sig   = OpenSSL::HMAC.digest("sha256", secret, payload)
+ *   signature = Base64.strict_encode64(raw_sig)
+ *   header    = "v1,#{signature}"
+ */
+function backendSignature(payload: string | Buffer, key: string, id: string, timestamp: string): string {
+    const body = typeof payload === "string" ? Buffer.from(payload, "utf8") : payload;
+    const signed = Buffer.concat([Buffer.from(`${id}.${timestamp}.`, "utf8"), body]);
+    return createHmac("sha256", key).update(signed).digest("base64");
+}
+
+interface SignatureHeaders extends Record<string, string> {
+    "webhook-id": string;
+    "webhook-timestamp": string;
+    "webhook-signature": string;
+}
 
 function signedHeaders({
     payload = PAYLOAD,
@@ -12,15 +36,16 @@ function signedHeaders({
     id = "msg_2Xa9",
     at = new Date(),
 }: {
-    payload?: string;
+    payload?: string | Buffer;
     key?: string;
     id?: string;
     at?: Date;
-} = {}): Record<string, string> {
+} = {}): SignatureHeaders {
+    const timestamp = String(Math.floor(at.getTime() / 1000));
     return {
         "webhook-id": id,
-        "webhook-timestamp": String(Math.floor(at.getTime() / 1000)),
-        "webhook-signature": new Webhook(key).sign(id, at, payload),
+        "webhook-timestamp": timestamp,
+        "webhook-signature": `v1,${backendSignature(payload, key, id, timestamp)}`,
     };
 }
 
@@ -44,12 +69,82 @@ describe("unwrapWebhook", () => {
         expect(unwrapWebhook<{ id: string }>(PAYLOAD, { headers, key: KEY }).id).toBe("evt_123");
     });
 
-    it("accepts a key without the whsec_ prefix", () => {
-        const bare = KEY.slice("whsec_".length);
+    it("signs over the exact bytes of the body", () => {
+        const payload = Buffer.from('{"id":"evt_123","note":"a\\u00e9b","emoji":"\u{1F600}"}', "utf8");
+        const headers = signedHeaders({ payload });
 
-        expect(unwrapWebhook<{ id: string }>(PAYLOAD, { headers: signedHeaders({ key: bare }), key: bare }).id).toBe(
-            "evt_123",
+        const signed = Buffer.concat([
+            Buffer.from(`${headers["webhook-id"]}.${headers["webhook-timestamp"]}.`, "utf8"),
+            payload,
+        ]);
+        const expected = createHmac("sha256", KEY).update(signed).digest("base64");
+
+        expect(headers["webhook-signature"]).toBe(`v1,${expected}`);
+        expect(unwrapWebhook<{ id: string }>(payload.toString("utf8"), { headers, key: KEY }).id).toBe("evt_123");
+    });
+
+    it("uses the secret verbatim without stripping a prefix", () => {
+        // The backend HMACs the stored secret as-is, so a secret and that same secret minus
+        // a prefix are two different keys. Stripping either one would silently derive the
+        // wrong key.
+        const prefixed = `whsec_${"9d4e".repeat(16)}`;
+        const bare = prefixed.slice("whsec_".length);
+
+        expect(
+            unwrapWebhook<{ id: string }>(PAYLOAD, { headers: signedHeaders({ key: prefixed }), key: prefixed }).id,
+        ).toBe("evt_123");
+        expect(() => unwrapWebhook(PAYLOAD, { headers: signedHeaders({ key: prefixed }), key: bare })).toThrow(
+            WebhookVerificationError,
         );
+    });
+
+    it.each([
+        (valid: string, filler: string) => `v1,${filler} ${valid}`,
+        (valid: string, filler: string) => `${valid} v1,${filler}`,
+        (valid: string, filler: string) => `v0,${filler} ${valid} v2,${filler}`,
+    ])("accepts a valid v1 entry in a multi-signature header (%#)", (build) => {
+        const headers = signedHeaders();
+        const value = build(headers["webhook-signature"], "A".repeat(44));
+
+        expect(
+            unwrapWebhook<{ id: string }>(PAYLOAD, { headers: { ...headers, "webhook-signature": value }, key: KEY })
+                .id,
+        ).toBe("evt_123");
+    });
+
+    // The nonce-bound scheme from https://github.com/whopio/whop/pull/23394:
+    // base64(HMAC(secret, "v1n.<id>.<timestamp>.<nonce>.<body>")), appended after the v1
+    // entry. That PR is closed and no deployed sender emits it — WebhooksManager::SignWebhook
+    // on main writes a single "v1,<sig>" entry — so the helper ignores v1n rather than
+    // verifying it. These pin that ignoring it stays harmless if the scheme ever ships: the
+    // v1 entry it travels beside is still the one that authenticates the delivery.
+    const nonceSignature = (id: string, timestamp: string, nonce: string) =>
+        createHmac("sha256", KEY).update(`v1n.${id}.${timestamp}.${nonce}.${PAYLOAD}`, "utf8").digest("base64");
+
+    it("ignores a v1n entry and verifies the v1 entry beside it", () => {
+        const headers = signedHeaders();
+        const nonce = "nonce_zRq4";
+        const v1n = nonceSignature(headers["webhook-id"], headers["webhook-timestamp"], nonce);
+
+        expect(
+            unwrapWebhook<{ id: string }>(PAYLOAD, {
+                headers: {
+                    ...headers,
+                    "webhook-nonce": nonce,
+                    "webhook-signature": `${headers["webhook-signature"]} v1n,${v1n}`,
+                },
+                key: KEY,
+            }).id,
+        ).toBe("evt_123");
+    });
+
+    it("rejects a header carrying only a v1n entry", () => {
+        const headers = signedHeaders();
+        const v1n = nonceSignature(headers["webhook-id"], headers["webhook-timestamp"], "nonce_zRq4");
+
+        expect(() =>
+            unwrapWebhook(PAYLOAD, { headers: { ...headers, "webhook-signature": `v1n,${v1n}` }, key: KEY }),
+        ).toThrow(WebhookVerificationError);
     });
 
     it("rejects a tampered payload", () => {

--- a/tests/unit/helpers/verifyWebhook.test.ts
+++ b/tests/unit/helpers/verifyWebhook.test.ts
@@ -1,0 +1,162 @@
+import { readFileSync } from "node:fs";
+import { Webhook, WebhookVerificationError } from "standardwebhooks";
+import { unwrapWebhook } from "../../../src/helpers/index.js";
+
+const KEY = "whsec_MfKQ9r8GKYqrTwjUPD8ILPZIo2LaLaSw";
+const OTHER_KEY = "whsec_C2FVsBQIhrscChlQIMV+b5sSYspob7oD";
+const PAYLOAD = '{"id":"evt_123","event":"payment.succeeded","data":{"id":"pay_123"}}';
+
+function signedHeaders({
+    payload = PAYLOAD,
+    key = KEY,
+    id = "msg_2Xa9",
+    at = new Date(),
+}: {
+    payload?: string;
+    key?: string;
+    id?: string;
+    at?: Date;
+} = {}): Record<string, string> {
+    return {
+        "webhook-id": id,
+        "webhook-timestamp": String(Math.floor(at.getTime() / 1000)),
+        "webhook-signature": new Webhook(key).sign(id, at, payload),
+    };
+}
+
+describe("unwrapWebhook", () => {
+    it("returns the parsed body for a valid signature", () => {
+        expect(unwrapWebhook(PAYLOAD, { headers: signedHeaders(), key: KEY })).toEqual({
+            id: "evt_123",
+            event: "payment.succeeded",
+            data: { id: "pay_123" },
+        });
+    });
+
+    it("accepts headers whose names are capitalized", () => {
+        const headers = Object.fromEntries(
+            Object.entries(signedHeaders()).map(([name, value]) => [
+                name.replace(/(^|-)([a-z])/g, (_, sep: string, char: string) => sep + char.toUpperCase()),
+                value,
+            ]),
+        );
+
+        expect(unwrapWebhook<{ id: string }>(PAYLOAD, { headers, key: KEY }).id).toBe("evt_123");
+    });
+
+    it("accepts a key without the whsec_ prefix", () => {
+        const bare = KEY.slice("whsec_".length);
+
+        expect(unwrapWebhook<{ id: string }>(PAYLOAD, { headers: signedHeaders({ key: bare }), key: bare }).id).toBe(
+            "evt_123",
+        );
+    });
+
+    it("rejects a tampered payload", () => {
+        expect(() =>
+            unwrapWebhook(PAYLOAD.replace("pay_123", "pay_456"), { headers: signedHeaders(), key: KEY }),
+        ).toThrow(WebhookVerificationError);
+    });
+
+    it("rejects a payload reserialized with the same content", () => {
+        const reserialized = JSON.stringify(JSON.parse(PAYLOAD), null, 2);
+
+        expect(reserialized).not.toBe(PAYLOAD);
+        expect(JSON.parse(reserialized)).toEqual(JSON.parse(PAYLOAD));
+        expect(() => unwrapWebhook(reserialized, { headers: signedHeaders(), key: KEY })).toThrow(
+            WebhookVerificationError,
+        );
+    });
+
+    it("rejects a signature made with a different key", () => {
+        expect(() => unwrapWebhook(PAYLOAD, { headers: signedHeaders({ key: OTHER_KEY }), key: KEY })).toThrow(
+            WebhookVerificationError,
+        );
+    });
+
+    it("rejects a signature bound to a different message id", () => {
+        const headers = { ...signedHeaders({ id: "msg_original" }), "webhook-id": "msg_replaced" };
+
+        expect(() => unwrapWebhook(PAYLOAD, { headers, key: KEY })).toThrow(WebhookVerificationError);
+    });
+
+    it("rejects a signature bound to a different timestamp", () => {
+        const now = new Date();
+        const headers = {
+            ...signedHeaders({ at: now }),
+            "webhook-timestamp": String(Math.floor(now.getTime() / 1000) - 60),
+        };
+
+        expect(() => unwrapWebhook(PAYLOAD, { headers, key: KEY })).toThrow(WebhookVerificationError);
+    });
+
+    it.each([-10, 10])("rejects a timestamp %d minutes outside the tolerance window", (minutes) => {
+        const at = new Date(Date.now() + minutes * 60_000);
+
+        expect(() => unwrapWebhook(PAYLOAD, { headers: signedHeaders({ at }), key: KEY })).toThrow(
+            WebhookVerificationError,
+        );
+    });
+
+    it.each(["webhook-id", "webhook-timestamp", "webhook-signature"])("rejects a missing %s header", (dropped) => {
+        const headers = { ...signedHeaders() };
+        delete headers[dropped];
+
+        expect(() => unwrapWebhook(PAYLOAD, { headers, key: KEY })).toThrow(WebhookVerificationError);
+    });
+
+    it.each([
+        "not-a-signature",
+        "v1,",
+        "v1,!!!!",
+        "v2,abc",
+        "",
+        "v1,a,b",
+        `v1,${"A".repeat(44)}`,
+    ])("rejects the malformed signature header %j", (signature) => {
+        const headers = { ...signedHeaders(), "webhook-signature": signature };
+
+        expect(() => unwrapWebhook(PAYLOAD, { headers, key: KEY })).toThrow(WebhookVerificationError);
+    });
+
+    it.each(["not-a-timestamp", "", "1e999"])("rejects the unparsable timestamp %j", (timestamp) => {
+        const headers = { ...signedHeaders(), "webhook-timestamp": timestamp };
+
+        expect(() => unwrapWebhook(PAYLOAD, { headers, key: KEY })).toThrow(WebhookVerificationError);
+    });
+
+    it.each([undefined, ""])("raises a clear error when the key is %j", (key) => {
+        expect(() => unwrapWebhook(PAYLOAD, { headers: signedHeaders(), key })).toThrow(/without a key/);
+    });
+
+    it("raises before verifying when the key is missing", () => {
+        expect(() => unwrapWebhook(PAYLOAD, { headers: {}, key: undefined })).toThrow(/without a key/);
+    });
+});
+
+describe("packaging", () => {
+    // src/helpers is kept by .fernignore, but package.json is generated: the dependency and
+    // the ./helpers subpath export are re-emitted from extraDependencies and packageJson in
+    // the typescript config in whop-monorepo sdks/fern/generators.yml. Without them the
+    // helper is either unreachable from the published package or fails to resolve its
+    // import at runtime.
+    const packageJson = JSON.parse(readFileSync(new URL("../../../package.json", import.meta.url), "utf8"));
+
+    it("declares standardwebhooks as a dependency", () => {
+        expect(packageJson.dependencies?.standardwebhooks).toBeTruthy();
+    });
+
+    it("exports ./helpers from the published package", () => {
+        expect(packageJson.exports?.["./helpers"]).toEqual({
+            import: {
+                types: "./dist/esm/helpers/index.d.mts",
+                default: "./dist/esm/helpers/index.mjs",
+            },
+            require: {
+                types: "./dist/cjs/helpers/index.d.ts",
+                default: "./dist/cjs/helpers/index.js",
+            },
+            default: "./dist/cjs/helpers/index.js",
+        });
+    });
+});


### PR DESCRIPTION
### Why

The Stainless package shipped `client.webhooks.unwrap` through 0.0.42. Fern generates from OpenAPI paths and `unwrap` was never a path, so all three Fern SDKs silently lost it and consumers are hand-rolling HMAC comparison — exactly the thing not to hand-roll.

### What changed?

- `unwrapWebhook(payload, { headers, key })`, ported from `@whop/sdk` 0.0.42 `src/resources/webhooks.ts:21`, reachable as `@whop/sdk/helpers`. Standalone, so nothing generated is patched. Verification only — the Stainless version also returned `UnwrapWebhookEvent`, a union of 42 generated event models Fern does not generate, so the return is `Record<string, unknown>` with an optional (unchecked) type parameter.
- `package.json` gains `standardwebhooks` and the `./helpers` subpath export. `src/index.ts` is generated, so a root re-export would mean forking a generated file; a subpath does not. Both are re-emitted by whopio/whop-monorepo#24922 — **merge that first**, or the next regeneration strips them and `@whop/sdk/helpers` stops resolving.
- `.fernignore` keeps `src/helpers` and `tests/unit/helpers`. Unlike Ruby, this repo's `ci.yml` is Fern's, so the "did the dependency and the export survive generation" guard is a test rather than a CI step.

One thing reviewers should weigh: this makes `@whop/sdk` non-zero-dependency for the first time since the cutover (`standardwebhooks` → `@stablelib/base64`, `fast-sha256`). The Stainless package carried the same dependency. Consumers who typecheck against `@whop/sdk/helpers` also need `@types/node`, because `standardwebhooks`'s `.d.ts` references `Buffer`.

### Verified by executing

`pnpm build`, `pnpm test:unit --run` (393 passed, 28 of them new), biome clean, and `pnpm pack` installed into a scratch project where `@whop/sdk/helpers` was imported and exercised from **both** CJS (`require`) and ESM (`import`), plus `tsc --noEmit` against the subpath under `moduleResolution` `node16` and `bundler`.