### PR TITLE
release: 1.0.13

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@whop/sdk",
-    "version": "1.0.11",
+    "version": "1.0.13",
     "private": false,
     "repository": {
         "type": "git",


### PR DESCRIPTION
### Why

Ships `unwrapWebhook` from `@whop/sdk/helpers` (#75) — webhook signature verification, which no Fern SDK had since the cutover.

Verified against genuine captured deliveries on a seeded devbox: 7/7 webhook scenarios pass, and the negative control (feeding the pre-fix `base64(secret)` key) still fails, so the test can go red.

### What changed?

`package.json` only — 1.0.11 → **1.0.13**, skipping 1.0.12 so all three SDKs land on the same version for this release. Ruby and Python are already at 1.0.12 published.

Supersedes #73 (`release: 1.0.12`), which predates the webhook helper — close it.