### PR TITLE
ci: approve fern-bot PRs so auto-merge can satisfy the required review

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -22,6 +22,12 @@ jobs:
       startsWith(github.event.pull_request.head.ref, 'fern-bot/')
     runs-on: ubuntu-latest
     steps:
+      - name: Approve
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: gh pr review "$PR_NUMBER" --repo "$GITHUB_REPOSITORY" --approve
+
       - name: Enable auto-merge
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Stacked on #77.

- Adds an `Approve` step to `auto-merge.yml`, under the same `if:` gate as the merge step, so it only ever runs on a `fern-api[bot]` PR from an in-repo `fern-bot/*` branch.
- Uses the job's own `GITHUB_TOKEN` (`pull-requests: write`, already declared). No new credential.
- The approval counts toward the required review because `can_approve_pull_request_reviews` is enabled on this repo.

**Why:** the ruleset requires 1 approving review, and auto-merge waits for every merge requirement rather than waiving them — so without this the workflow arms a PR that then sits forever. Granting GitHub Actions a ruleset bypass instead is not possible: GitHub rejects it with `Actor GitHub Actions integration must be part of the ruleset source or owner organization`.

Known gap: `required_review_thread_resolution` is on, so an unresolved comment on a regeneration PR still stalls auto-merge. Fails safe.