### PR TITLE
release: @whop/sdk 1.1.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@whop/sdk",
-    "version": "1.1.1",
+    "version": "1.1.2",
     "private": false,
     "repository": {
         "type": "git",


### PR DESCRIPTION
Publish the corrected Fern-generated TypeScript SDK after whopio/whop-monorepo#27463 and SDK regeneration #92. Version `1.1.2` is required because stale `1.1.1` was already published and npm versions are immutable.

This PR changes only `package.json` version metadata, which triggers the repository publish workflow.

Pre-publish validation:
- `pnpm run format`
- `pnpm run lint` and `pnpm run check` (174 existing warnings, zero errors)
- `pnpm run build` / TypeScript compilation
- `CI=true pnpm test` (119 files, 2,414 tests passed)
- `npm pack`: package and runtime SDK version `1.1.2`, 7,663 files
- packed artifact search: zero exact `company_id` matches
- representative TypeScript requests for affiliates, experiences, forum posts, DM channels, support channels, fee markups, access tokens, account links, payout methods, and stats accept `account_id`