### PR TITLE
fix(sdk): preserve fetch queries and release experiments

### DIFF
--- a/.fernignore
+++ b/.fernignore
@@ -42,3 +42,6 @@
 .gitattributes
 src/helpers
 tests/unit/helpers
+# Remove these overrides when Fern's passthrough fetch preserves relative URL queries.
+src/core/fetcher/makePassthroughRequest.ts
+tests/unit/fetcher/makePassthroughRequest.test.ts

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@whop/sdk",
-    "version": "1.1.3",
+    "version": "1.1.4",
     "private": false,
     "repository": {
         "type": "git",

--- a/src/core/fetcher/makePassthroughRequest.ts
+++ b/src/core/fetcher/makePassthroughRequest.ts
@@ -1,5 +1,4 @@
 import { createLogger, type LogConfig, type Logger } from "../logging/logger.js";
-import { join } from "../url/join.js";
 import { EndpointSupplier } from "./EndpointSupplier.js";
 import { getFetchFn } from "./getFetchFn.js";
 import { makeRequest } from "./makeRequest.js";
@@ -97,7 +96,7 @@ export async function makePassthroughRequest(
     if (url.startsWith("http://") || url.startsWith("https://")) {
         fullUrl = url;
     } else if (baseUrl != null) {
-        fullUrl = join(baseUrl, url);
+        fullUrl = new URL(url.replace(/^\/+/, ""), `${baseUrl.replace(/\/+$/, "")}/`).toString();
     } else {
         fullUrl = url;
     }

--- a/tests/unit/fetcher/makePassthroughRequest.test.ts
+++ b/tests/unit/fetcher/makePassthroughRequest.test.ts
@@ -10,6 +10,24 @@ describe("makePassthroughRequest", () => {
     });
 
     describe("URL resolution", () => {
+        it.each([
+            "/experiments?account_id=biz_test&first=20",
+            "experiments?account_id=biz_test&first=20",
+            "/experiments?account_id=biz_test&properties=%7B%22theme%22%3A%22blue%22%7D",
+        ])("preserves query parameters in %s", async (path) => {
+            await makePassthroughRequest(path, undefined, {
+                baseUrl: "https://api.whop.com/api/v1/",
+                fetch: mockFetch,
+                headers: { "Api-Version-Date": "2026-09-11" },
+                getAuthHeaders: async () => ({ Authorization: "Bearer test-token" }),
+            });
+
+            const [calledUrl, options] = mockFetch.mock.calls[0];
+            expect(calledUrl).toBe(`https://api.whop.com/api/v1/${path.replace(/^\//, "")}`);
+            expect(options.headers.authorization).toBe("Bearer test-token");
+            expect(options.headers["api-version-date"]).toBe("2026-09-11");
+        });
+
         it("should use absolute URL directly", async () => {
             await makePassthroughRequest("https://api.example.com/v1/users", undefined, {
                 fetch: mockFetch,


### PR DESCRIPTION
### Why / Prompt
Relative raw requests such as `client.fetch('/experiments?account_id=biz_...')` encoded the query into the URL path. Published SDK 1.1.3 also predates the generated experiment methods and account-scoped API contract.

### What changed?
Preserve relative URL query strings and the API base path. Release the current generated SDK as 1.1.4, including experiment methods and API version 2026-09-11. Protect the transport fix and its tests from regeneration until Fern fixes URL handling upstream.

Validated with 43 passing passthrough tests and both CJS/ESM builds. Biome passes with two existing test warnings.
